### PR TITLE
Add volume_name cli argument

### DIFF
--- a/kaitaifs/cli.py
+++ b/kaitaifs/cli.py
@@ -41,6 +41,14 @@ def parse_args():
         type=str,
         help='mount point'
     )
+    parser.add_argument(
+        "volume_name",
+        metavar="VOLUME_NAME",
+        type=str,
+        help="volume name (osxfuse and winfsp only)",
+        nargs="?",
+        default="Kaitai",
+    )
     return parser.parse_args()
 
 
@@ -51,7 +59,8 @@ def main():
         fs_class(args.image_file),
         args.mount_point,
         nothreads=True,
-        foreground=True
+        foreground=True,
+        volname=args.volume_name
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR includes minor improvements to the README file and gives **Prerequisites** its own section with entries for Linux, Mac OS X and Windows.

- Is `libfuse` the correct Linux package? Alternatively it could be called just `FUSE` as it was before
- `osxfuse` comes recommended by `libfuse`
- the latest `fuse.py` works on Windows with `winfsp`. There are currently no new releases uploaded to PyPI, see: fusepy/fusepy/issues/118. Once this is resolved the extra info can be removed and all a Windows user has to do is run `setup.py`