### PR TITLE
Fix setup.py reading setup.cfg manually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 from setuptools import setup
-from setuptools.config import read_configuration
-from pathlib import Path
 
-cfg = read_configuration(str(Path(__file__).parent / 'setup.cfg'))
-#print(cfg)
-cfg["options"].update(cfg["metadata"])
-cfg = cfg["options"]
-setup(**cfg)
+setup()


### PR DESCRIPTION
Fixes #20.

Reading setup.cfg manually is not supported by setuptools and causes errors with some setup.cfg features (see pypa/setuptools#1869). The supported way to use setup.cfg is to call `setup()` with no arguments and let setuptools read and parse setup.cfg itself.