### PR TITLE
Replace deprecated `requires` in `setup.cfg` with `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ include_package_data = True
 packages = find:
 setup_requires = setuptools_scm;
 install_requires =
-    enum34
+    enum34; python_version < "3.4"
     fusepy
     kaitaistruct
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ version = 0.1.0
 url = https://github.com/kaitai-io/kaitai_fs
 long_description = file: README.rst
 license = GPL-3.0+
-requires = enum34, fusepy, kaitaistruct
 
 [entry_points.console_scripts]
 kaitaifs = kaitaifs.cli:main
@@ -14,6 +13,10 @@ zip_safe = True
 include_package_data = True
 packages = find:
 setup_requires = setuptools_scm;
+install_requires =
+    enum34
+    fusepy
+    kaitaistruct
 
 [build-system]
 requires = ["setuptools", "setuptools_scm", "wheel"]


### PR DESCRIPTION
Using `requires` in `setup.cfg` is deprecated and has been marked for exclusion for a while.

I am assuming that you are interested in linking runtime requirements from PyPI, so I am proposing in this PR to replace `requires` with `install_requires`.